### PR TITLE
Fix Runes tag parsing

### DIFF
--- a/modules/runes/runes/tag.go
+++ b/modules/runes/runes/tag.go
@@ -69,8 +69,26 @@ func ParseTag(input interface{}) (Tag, error) {
 		return input, nil
 	case uint128.Uint128:
 		return Tag(input), nil
-	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
-		return Tag(uint128.From64(input.(uint64))), nil
+	case int:
+		return Tag(uint128.From64(uint64(input))), nil
+	case int8:
+		return Tag(uint128.From64(uint64(input))), nil
+	case int16:
+		return Tag(uint128.From64(uint64(input))), nil
+	case int32:
+		return Tag(uint128.From64(uint64(input))), nil
+	case int64:
+		return Tag(uint128.From64(uint64(input))), nil
+	case uint:
+		return Tag(uint128.From64(uint64(input))), nil
+	case uint8:
+		return Tag(uint128.From64(uint64(input))), nil
+	case uint16:
+		return Tag(uint128.From64(uint64(input))), nil
+	case uint32:
+		return Tag(uint128.From64(uint64(input))), nil
+	case uint64:
+		return Tag(uint128.From64(input)), nil
 	case big.Int:
 		u128, err := uint128.FromBig(&input)
 		if err != nil {


### PR DESCRIPTION
## Description
Current Runes tag parsing results in a panic if input is non-uint64 integers. This PR fixes that by defining different cases for each type.

## Type of change

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Enhancement (improvement to existing features and functionality)
- [ ] Documentation update (changes to documentation)
- [ ] Performance improvement (non-breaking change which improves efficiency)
- [ ] Code consistency (non-breaking change which improves code reliability and robustness)

## Commit formatting

Please follow the commit message conventions for an easy way to identify the purpose or intention of a commit. Check out our commit message conventions in the [CONTRIBUTING.md](https://github.com/gaze-network/gaze-indexer/blob/main/.github/CONTRIBUTING.md#pull-requests-or-commits)
