### PR TITLE
build: add Docker cache mound for Go modules

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,18 @@
-Dockerfile
-.dockerignore
 .git
+.gitignore
 .github
 .vscode
 **/*.md
 **/*.log
+.DS_Store
+
+# Docker
+Dockerfile
+.dockerignore
+docker-compose.yml
+
+# Go
+.golangci.yaml
 cmd.local
+config.*.y*ml
+config.y*ml

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+Dockerfile
+.dockerignore
+.git
+.github
+.vscode
+**/*.md
+**/*.log
+cmd.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ COPY --from=builder /app/main .
 # You can set TZ indentifier to change the timezone, See https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List
 # ENV TZ=US/Central
 
-CMD ["/app/main", "run"]
+ENTRYPOINT ["/app/main"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apk --no-cache add ca-certificates tzdata
 COPY --from=builder /app/main .
 COPY --from=builder /app/modules ./modules
 
-# You can set TZ indentifier to change the timezone, See https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List
+# You can set TZ identifier to change the timezone, See https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List
 # ENV TZ=US/Central
 
 ENTRYPOINT ["/app/main"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apk --no-cache add ca-certificates tzdata
 
 COPY --from=builder /app/main .
 
-# You can set `TZ` environment variable to change the timezone
+# You can set TZ indentifier to change the timezone, See https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List
+# ENV TZ=US/Central
 
 CMD ["/app/main", "run"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,15 +3,15 @@ FROM golang:1.22 as builder
 WORKDIR /app
 
 COPY go.mod go.sum ./
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod/ go mod download
 
 COPY ./ ./
 
 ENV GOOS=linux
 ENV CGO_ENABLED=0
 
-RUN go build \
-          -o main ./main.go
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+    go build -o main ./main.go
 
 FROM alpine:latest
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ WORKDIR /app
 
 RUN apk --no-cache add ca-certificates tzdata
 
-
 COPY --from=builder /app/main .
+COPY --from=builder /app/modules ./modules
 
 # You can set TZ indentifier to change the timezone, See https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List
 # ENV TZ=US/Central


### PR DESCRIPTION
## Description
- According to the [Docker Mounts](https://docs.docker.com/build/guide/mounts/#add-a-cache-mount), so `go mod download` will download only necessary modules if `go.mod` or `go.sum` was changed.
- Add `TZ` env example and add more description detail.
- Use `entrypoint` instead `cmd` to make this image easier to run other commands.

## Type of change

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Enhancement (improvement to existing features and functionality)
- [x] Documentation update (changes to documentation)
- [x] Performance improvement (non-breaking change which improves efficiency)
- [ ] Code consistency (non-breaking change which improves code reliability and robustness)

## Commit formatting

Please follow the commit message conventions for an easy way to identify the purpose or intention of a commit. Check out our commit message conventions in the [CONTRIBUTING.md](https://github.com/gaze-network/gaze-indexer/blob/main/.github/CONTRIBUTING.md#pull-requests-or-commits)
