### PR TITLE
feat: use current indexed block for first prev block

### DIFF
--- a/core/indexer/indexer.go
+++ b/core/indexer/indexer.go
@@ -205,7 +205,7 @@ func (i *Indexer[T]) process(ctx context.Context) (err error) {
 
 			// validate is input is continuous and no reorg
 			prevHeader := i.currentBlock
-			for _, input := range inputs {
+			for i, input := range inputs {
 				header := input.BlockHeader()
 				if header.Height != prevHeader.Height+1 {
 					return errors.Wrapf(errs.InternalError, "input is not continuous, input[%d] height: %d, input[%d] height: %d", i-1, prevHeader.Height, i, header.Height)
@@ -217,6 +217,7 @@ func (i *Indexer[T]) process(ctx context.Context) (err error) {
 					// end current round
 					return nil
 				}
+				prevHeader = header
 			}
 
 			ctx = logger.WithContext(ctx, slog.Int("total_inputs", len(inputs)))

--- a/core/indexer/indexer.go
+++ b/core/indexer/indexer.go
@@ -204,9 +204,9 @@ func (i *Indexer[T]) process(ctx context.Context) (err error) {
 			}
 
 			// validate is input is continuous and no reorg
-			for i := 1; i < len(inputs); i++ {
-				header := inputs[i].BlockHeader()
-				prevHeader := inputs[i-1].BlockHeader()
+			prevHeader := i.currentBlock
+			for _, input := range inputs {
+				header := input.BlockHeader()
 				if header.Height != prevHeader.Height+1 {
 					return errors.Wrapf(errs.InternalError, "input is not continuous, input[%d] height: %d, input[%d] height: %d", i-1, prevHeader.Height, i, header.Height)
 				}


### PR DESCRIPTION
## Description
use current indexed block for first prev block in continuous blocks validation 

## Type of change

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Enhancement (improvement to existing features and functionality)
- [ ] Documentation update (changes to documentation)
- [ ] Performance improvement (non-breaking change which improves efficiency)
- [ ] Code consistency (non-breaking change which improves code reliability and robustness)

## Commit formatting

Please follow the commit message conventions for an easy way to identify the purpose or intention of a commit. Check out our commit message conventions in the [CONTRIBUTING.md](https://github.com/gaze-network/gaze-indexer/blob/main/.github/CONTRIBUTING.md#pull-requests-or-commits)
