### PR TITLE
fix(httpclient): can't use base url path

### DIFF
--- a/pkg/httpclient/httpclient.go
+++ b/pkg/httpclient/httpclient.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Cleverse/go-utilities/utils"
 	"github.com/cockroachdb/errors"
 	"github.com/gaze-network/indexer-network/pkg/logger"
 	"github.com/valyala/fasthttp"
@@ -24,12 +23,13 @@ type Config struct {
 }
 
 type Client struct {
-	baseURL string
+	baseURL *url.URL
 	Config
 }
 
 func New(baseURL string, config ...Config) (*Client, error) {
-	if _, err := url.Parse(baseURL); err != nil {
+	parsedBaseURL, err := url.Parse(baseURL)
+	if err != nil {
 		return nil, errors.Wrap(err, "can't parse base url")
 	}
 	var cf Config
@@ -40,7 +40,7 @@ func New(baseURL string, config ...Config) (*Client, error) {
 		cf.Headers = make(map[string]string)
 	}
 	return &Client{
-		baseURL: baseURL,
+		baseURL: parsedBaseURL,
 		Config:  cf,
 	}, nil
 }
@@ -88,7 +88,7 @@ func (h *Client) request(ctx context.Context, reqOptions RequestOptions) (*HttpR
 		req.Header.Set(k, v)
 	}
 	// TODO: optimize performance, reduce unnecessary ops
-	parsedUrl := utils.Must(url.Parse(h.baseURL)) // checked in httpclient.New
+	parsedUrl := h.BaseURL()
 	parsedUrl.Path = path.Join(parsedUrl.Path, reqOptions.path)
 	parsedUrl.RawQuery = reqOptions.Query.Encode() // TODO: merge query params if base url already have query params
 
@@ -144,6 +144,12 @@ func (h *Client) request(ctx context.Context, reqOptions RequestOptions) (*HttpR
 	resp.CopyTo(&httpResponse.Response)
 
 	return &httpResponse, nil
+}
+
+// BaseURL returns the cloned base URL of the client.
+func (h *Client) BaseURL() *url.URL {
+	u := *h.baseURL
+	return &u
 }
 
 func (h *Client) Do(ctx context.Context, method, path string, reqOptions RequestOptions) (*HttpResponse, error) {

--- a/pkg/httpclient/httpclient.go
+++ b/pkg/httpclient/httpclient.go
@@ -87,7 +87,7 @@ func (h *Client) request(ctx context.Context, reqOptions RequestOptions) (*HttpR
 	for k, v := range reqOptions.Header {
 		req.Header.Set(k, v)
 	}
-	// TODO: optimize performance, reduce unnecessary ops
+
 	parsedUrl := h.BaseURL()
 	parsedUrl.Path = path.Join(parsedUrl.Path, reqOptions.path)
 	parsedUrl.RawQuery = reqOptions.Query.Encode() // TODO: merge query params if base url already have query params

--- a/pkg/httpclient/httpclient.go
+++ b/pkg/httpclient/httpclient.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 
@@ -88,8 +89,8 @@ func (h *Client) request(ctx context.Context, reqOptions RequestOptions) (*HttpR
 	}
 	// TODO: optimize performance, reduce unnecessary ops
 	parsedUrl := utils.Must(url.Parse(h.baseURL)) // checked in httpclient.New
-	parsedUrl.Path = reqOptions.path
-	parsedUrl.RawQuery = reqOptions.Query.Encode()
+	parsedUrl.Path = path.Join(parsedUrl.Path, reqOptions.path)
+	parsedUrl.RawQuery = reqOptions.Query.Encode() // TODO: merge query params if base url already have query params
 
 	// remove %20 from url (empty space)
 	url := strings.TrimSuffix(parsedUrl.String(), "%20")


### PR DESCRIPTION
## Description
- merge base url path with request path with `path.Join`
- add `BaseURL()` method to prevent baseURL parsing for every request call

## Type of change

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Enhancement (improvement to existing features and functionality)
- [ ] Documentation update (changes to documentation)
- [x] Performance improvement (non-breaking change which improves efficiency)
- [ ] Code consistency (non-breaking change which improves code reliability and robustness)

## Commit formatting

Please follow the commit message conventions for an easy way to identify the purpose or intention of a commit. Check out our commit message conventions in the [CONTRIBUTING.md](https://github.com/gaze-network/gaze-indexer/blob/main/.github/CONTRIBUTING.md#pull-requests-or-commits)
