### PR TITLE
fix: incorrect condition for finding output destinations

### DIFF
--- a/modules/runes/processor_process.go
+++ b/modules/runes/processor_process.go
@@ -146,7 +146,7 @@ func (p *Processor) processTx(ctx context.Context, tx *types.Transaction, blockH
 					// find all non-OP_RETURN outputs
 					var destinations []int
 					for i, txOut := range tx.TxOut {
-						if txOut.IsOpReturn() {
+						if !txOut.IsOpReturn() {
 							destinations = append(destinations, i)
 						}
 					}


### PR DESCRIPTION
## Description

Currently, when edict output is equal to the number of transaction outputs, it is supposed to equally allocate runes to all non-OP_RETURN outputs, but we are allocating to ONLY OP_RETURN outputs. This fix changes the destination condition.

## Type of change

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Enhancement (improvement to existing features and functionality)
- [ ] Documentation update (changes to documentation)
- [ ] Performance improvement (non-breaking change which improves efficiency)
- [ ] Code consistency (non-breaking change which improves code reliability and robustness)

## Commit formatting

Please follow the commit message conventions for an easy way to identify the purpose or intention of a commit. Check out our commit message conventions in the [CONTRIBUTING.md](https://github.com/gaze-network/gaze-indexer/blob/main/.github/CONTRIBUTING.md#pull-requests-or-commits)
