### PR TITLE
fix: add decimals field in runes get holders

### DIFF
--- a/modules/runes/api/httphandler/get_holders.go
+++ b/modules/runes/api/httphandler/get_holders.go
@@ -51,6 +51,7 @@ type getHoldersResult struct {
 	BlockHeight  uint64           `json:"blockHeight"`
 	TotalSupply  uint128.Uint128  `json:"totalSupply"`
 	MintedAmount uint128.Uint128  `json:"mintedAmount"`
+	Decimals     uint8            `json:"decimals"`
 	List         []holdingBalance `json:"list"`
 }
 
@@ -140,6 +141,7 @@ func (h *HttpHandler) GetHolders(ctx *fiber.Ctx) (err error) {
 			BlockHeight:  blockHeight,
 			TotalSupply:  totalSupply,
 			MintedAmount: mintedAmount,
+			Decimals:     runeEntry.Divisibility,
 			List:         list,
 		},
 	}


### PR DESCRIPTION
## Description

The Runes Get Holders API was missing the "decimals" field.

## Type of change

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Enhancement (improvement to existing features and functionality)
- [ ] Documentation update (changes to documentation)
- [ ] Performance improvement (non-breaking change which improves efficiency)
- [ ] Code consistency (non-breaking change which improves code reliability and robustness)

## Commit formatting

Please follow the commit message conventions for an easy way to identify the purpose or intention of a commit. Check out our commit message conventions in the [CONTRIBUTING.md](https://github.com/gaze-network/gaze-indexer/blob/main/.github/CONTRIBUTING.md#pull-requests-or-commits)
