### PR TITLE
feat: add dust limit util

### DIFF
--- a/pkg/btcutils/address.go
+++ b/pkg/btcutils/address.go
@@ -150,6 +150,18 @@ func (a Address) Equal(b Address) bool {
 	return a.encoded == b.encoded
 }
 
+// DustLimit returns the output dust limit (lowest possible satoshis in a UTXO) for the address type.
+func (a Address) DustLimit() uint64 {
+	switch a.encodedType {
+	case AddressP2TR:
+		return 330
+	case AddressP2WPKH:
+		return 294
+	default:
+		return 546
+	}
+}
+
 // MarshalText implements the encoding.TextMarshaler interface.
 func (a Address) MarshalText() ([]byte, error) {
 	return []byte(a.encoded), nil

--- a/pkg/btcutils/address.go
+++ b/pkg/btcutils/address.go
@@ -151,7 +151,7 @@ func (a Address) Equal(b Address) bool {
 }
 
 // DustLimit returns the output dust limit (lowest possible satoshis in a UTXO) for the address type.
-func (a Address) DustLimit() uint64 {
+func (a Address) DustLimit() int64 {
 	switch a.encodedType {
 	case AddressP2TR:
 		return 330

--- a/pkg/btcutils/address_test.go
+++ b/pkg/btcutils/address_test.go
@@ -447,3 +447,72 @@ func TestAddressPkScript(t *testing.T) {
 		})
 	}
 }
+
+func TestAddressDustLimit(t *testing.T) {
+	type Spec struct {
+		Address           string
+		DefaultNet        *chaincfg.Params
+		ExpectedDustLimit int64
+	}
+
+	specs := []Spec{
+		{
+			Address:           "bc1qfpgdxtpl7kz5qdus2pmexyjaza99c28q8uyczh",
+			DefaultNet:        &chaincfg.MainNetParams,
+			ExpectedDustLimit: 294,
+		},
+		{
+			Address:           "tb1qfpgdxtpl7kz5qdus2pmexyjaza99c28qd6ltey",
+			DefaultNet:        &chaincfg.MainNetParams,
+			ExpectedDustLimit: 294,
+		},
+		{
+			Address:           "bc1p7h87kqsmpzatddzhdhuy9gmxdpvn5kvar6hhqlgau8d2ffa0pa3qvz5d38",
+			DefaultNet:        &chaincfg.MainNetParams,
+			ExpectedDustLimit: 330,
+		},
+		{
+			Address:           "tb1p7h87kqsmpzatddzhdhuy9gmxdpvn5kvar6hhqlgau8d2ffa0pa3qm2zztg",
+			DefaultNet:        &chaincfg.MainNetParams,
+			ExpectedDustLimit: 330,
+		},
+		{
+			Address:           "3Ccte7SJz71tcssLPZy3TdWz5DTPeNRbPw",
+			DefaultNet:        &chaincfg.MainNetParams,
+			ExpectedDustLimit: 546,
+		},
+		{
+			Address:           "1KrRZSShVkdc8J71CtY4wdw46Rx3BRLKyH",
+			DefaultNet:        &chaincfg.MainNetParams,
+			ExpectedDustLimit: 546,
+		},
+		{
+			Address:           "bc1qeklep85ntjz4605drds6aww9u0qr46qzrv5xswd35uhjuj8ahfcqgf6hak",
+			DefaultNet:        &chaincfg.MainNetParams,
+			ExpectedDustLimit: 546,
+		},
+		{
+			Address:           "migbBPcDajPfffrhoLpYFTQNXQFbWbhpz3",
+			DefaultNet:        &chaincfg.TestNet3Params,
+			ExpectedDustLimit: 546,
+		},
+		{
+			Address:           "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7",
+			DefaultNet:        &chaincfg.MainNetParams,
+			ExpectedDustLimit: 546,
+		},
+		{
+			Address:           "2NCxMvHPTduZcCuUeAiWUpuwHga7Y66y9XJ",
+			DefaultNet:        &chaincfg.TestNet3Params,
+			ExpectedDustLimit: 546,
+		},
+	}
+
+	for _, spec := range specs {
+		t.Run(spec.Address, func(t *testing.T) {
+			addr, err := btcutils.SafeNewAddress(spec.Address, spec.DefaultNet)
+			require.NoError(t, err)
+			assert.Equal(t, spec.ExpectedDustLimit, addr.DustLimit())
+		})
+	}
+}


### PR DESCRIPTION
## Description

Adds DustLimit method for `btcutils.Address` type.

## Type of change

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Enhancement (improvement to existing features and functionality)
- [ ] Documentation update (changes to documentation)
- [ ] Performance improvement (non-breaking change which improves efficiency)
- [ ] Code consistency (non-breaking change which improves code reliability and robustness)

## Commit formatting

Please follow the commit message conventions for an easy way to identify the purpose or intention of a commit. Check out our commit message conventions in the [CONTRIBUTING.md](https://github.com/gaze-network/gaze-indexer/blob/main/.github/CONTRIBUTING.md#pull-requests-or-commits)
