### PR TITLE
fix: add different genesis runes config for each network

### DIFF
--- a/modules/runes/constants/constants.go
+++ b/modules/runes/constants/constants.go
@@ -2,12 +2,16 @@ package constants
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/Cleverse/go-utilities/utils"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/gaze-network/indexer-network/common"
 	"github.com/gaze-network/indexer-network/core/types"
+	"github.com/gaze-network/indexer-network/modules/runes/runes"
 	"github.com/gaze-network/indexer-network/pkg/logger"
+	"github.com/gaze-network/uint128"
+	"github.com/samber/lo"
 )
 
 const (
@@ -32,6 +36,84 @@ var StartingBlockHeader = map[common.Network]types.BlockHeader{
 	common.NetworkFractalTestnet: {
 		Height: 83999,
 		Hash:   *utils.Must(chainhash.NewHashFromStr("00000000000000613ddfbdd1778b17cea3818febcbbf82762eafaa9461038343")),
+	},
+}
+
+type GenesisRuneConfig struct {
+	RuneId        runes.RuneId
+	Name          string
+	Number        uint64
+	Divisibility  uint8
+	Premine       uint128.Uint128
+	SpacedRune    runes.SpacedRune
+	Symbol        rune
+	Terms         *runes.Terms
+	Turbo         bool
+	EtchingBlock  uint64
+	EtchingTxHash chainhash.Hash
+	EtchedAt      time.Time
+}
+
+var GenesisRuneConfigMap = map[common.Network]GenesisRuneConfig{
+	common.NetworkMainnet: {
+		RuneId:       runes.RuneId{BlockHeight: 1, TxIndex: 0},
+		Number:       0,
+		Divisibility: 0,
+		Premine:      uint128.Zero,
+		SpacedRune:   runes.NewSpacedRune(runes.NewRune(2055900680524219742), 0b10000000),
+		Symbol:       '\u29c9',
+		Terms: &runes.Terms{
+			Amount:      lo.ToPtr(uint128.From64(1)),
+			Cap:         &uint128.Max,
+			HeightStart: lo.ToPtr(uint64(840000)),
+			HeightEnd:   lo.ToPtr(uint64(1050000)),
+			OffsetStart: nil,
+			OffsetEnd:   nil,
+		},
+		Turbo:         true,
+		EtchingBlock:  1,
+		EtchingTxHash: chainhash.Hash{},
+		EtchedAt:      time.Time{},
+	},
+	common.NetworkFractalMainnet: {
+		RuneId:       runes.RuneId{BlockHeight: 1, TxIndex: 0},
+		Number:       0,
+		Divisibility: 0,
+		Premine:      uint128.Zero,
+		SpacedRune:   runes.NewSpacedRune(runes.NewRune(2055900680524219742), 0b10000000),
+		Symbol:       '\u29c9',
+		Terms: &runes.Terms{
+			Amount:      lo.ToPtr(uint128.From64(1)),
+			Cap:         &uint128.Max,
+			HeightStart: lo.ToPtr(uint64(84000)),
+			HeightEnd:   lo.ToPtr(uint64(2184000)),
+			OffsetStart: nil,
+			OffsetEnd:   nil,
+		},
+		Turbo:         true,
+		EtchingBlock:  1,
+		EtchingTxHash: chainhash.Hash{},
+		EtchedAt:      time.Time{},
+	},
+	common.NetworkFractalTestnet: {
+		RuneId:       runes.RuneId{BlockHeight: 1, TxIndex: 0},
+		Number:       0,
+		Divisibility: 0,
+		Premine:      uint128.Zero,
+		SpacedRune:   runes.NewSpacedRune(runes.NewRune(2055900680524219742), 0b10000000),
+		Symbol:       '\u29c9',
+		Terms: &runes.Terms{
+			Amount:      lo.ToPtr(uint128.From64(1)),
+			Cap:         &uint128.Max,
+			HeightStart: lo.ToPtr(uint64(84000)),
+			HeightEnd:   lo.ToPtr(uint64(2184000)),
+			OffsetStart: nil,
+			OffsetEnd:   nil,
+		},
+		Turbo:         true,
+		EtchingBlock:  1,
+		EtchingTxHash: chainhash.Hash{},
+		EtchedAt:      time.Time{},
 	},
 }
 

--- a/modules/runes/constants/constants.go
+++ b/modules/runes/constants/constants.go
@@ -49,7 +49,6 @@ type GenesisRuneConfig struct {
 	Symbol        rune
 	Terms         *runes.Terms
 	Turbo         bool
-	EtchingBlock  uint64
 	EtchingTxHash chainhash.Hash
 	EtchedAt      time.Time
 }
@@ -71,7 +70,6 @@ var GenesisRuneConfigMap = map[common.Network]GenesisRuneConfig{
 			OffsetEnd:   nil,
 		},
 		Turbo:         true,
-		EtchingBlock:  1,
 		EtchingTxHash: chainhash.Hash{},
 		EtchedAt:      time.Time{},
 	},
@@ -91,7 +89,6 @@ var GenesisRuneConfigMap = map[common.Network]GenesisRuneConfig{
 			OffsetEnd:   nil,
 		},
 		Turbo:         true,
-		EtchingBlock:  1,
 		EtchingTxHash: chainhash.Hash{},
 		EtchedAt:      time.Time{},
 	},
@@ -111,7 +108,6 @@ var GenesisRuneConfigMap = map[common.Network]GenesisRuneConfig{
 			OffsetEnd:   nil,
 		},
 		Turbo:         true,
-		EtchingBlock:  1,
 		EtchingTxHash: chainhash.Hash{},
 		EtchedAt:      time.Time{},
 	},

--- a/modules/runes/processor.go
+++ b/modules/runes/processor.go
@@ -128,7 +128,7 @@ func (p *Processor) ensureGenesisRune(ctx context.Context, network common.Networ
 	if errors.Is(err, errs.NotFound) {
 		genesisRuneConfig, ok := constants.GenesisRuneConfigMap[network]
 		if !ok {
-			logger.Panic("genesis rune config not found", slogx.String("network", network.String()))
+			logger.Panic("genesis rune config not found", slogx.Stringer("network", network))
 		}
 		runeEntry := &runes.RuneEntry{
 			RuneId:            genesisRuneConfig.RuneId,


### PR DESCRIPTION
## Description

Add different genesis runes config for each network, most notably HeightStart and HeightEnd

## Type of change

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Enhancement (improvement to existing features and functionality)
- [ ] Documentation update (changes to documentation)
- [ ] Performance improvement (non-breaking change which improves efficiency)
- [ ] Code consistency (non-breaking change which improves code reliability and robustness)

## Commit formatting

Please follow the commit message conventions for an easy way to identify the purpose or intention of a commit. Check out our commit message conventions in the [CONTRIBUTING.md](https://github.com/gaze-network/gaze-indexer/blob/main/.github/CONTRIBUTING.md#pull-requests-or-commits)
