### PR TITLE
fix: only check for chain reorg if current block has hash

### DIFF
--- a/modules/runes/constants/constants.go
+++ b/modules/runes/constants/constants.go
@@ -20,6 +20,7 @@ const (
 	EventHashVersion = 1
 )
 
+// starting block heights and hashes should be 1 block before activation block, as indexer will start from the block after this value
 var StartingBlockHeader = map[common.Network]types.BlockHeader{
 	common.NetworkMainnet: {
 		Height: 839999,


### PR DESCRIPTION
## Description

Changes the core indexer logic to check for chain reorg ONLY if current block has block hash. This allow running the indexer for a protocol that has not activated yet (since we don't know the block hash of the activation block, only the height).

Protocol processors should return current block with an activation height and empty hash if CurrentBlock() is called and no block is indexed yet.

## Type of change

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Enhancement (improvement to existing features and functionality)
- [ ] Documentation update (changes to documentation)
- [ ] Performance improvement (non-breaking change which improves efficiency)
- [ ] Code consistency (non-breaking change which improves code reliability and robustness)

## Commit formatting

Please follow the commit message conventions for an easy way to identify the purpose or intention of a commit. Check out our commit message conventions in the [CONTRIBUTING.md](https://github.com/gaze-network/gaze-indexer/blob/main/.github/CONTRIBUTING.md#pull-requests-or-commits)
