### PR TITLE
fix: unescape query id in http handlers

### DIFF
--- a/modules/runes/api/httphandler/get_balances_by_address.go
+++ b/modules/runes/api/httphandler/get_balances_by_address.go
@@ -1,6 +1,8 @@
 package httphandler
 
 import (
+	"net/url"
+
 	"github.com/cockroachdb/errors"
 	"github.com/gaze-network/indexer-network/common/errs"
 	"github.com/gaze-network/indexer-network/modules/runes/internal/entity"
@@ -22,13 +24,20 @@ const (
 	getBalancesDefaultLimit = 100
 )
 
-func (r getBalancesRequest) Validate() error {
+func (r *getBalancesRequest) Validate() error {
 	var errList []error
 	if r.Wallet == "" {
 		errList = append(errList, errors.New("'wallet' is required"))
 	}
-	if r.Id != "" && !isRuneIdOrRuneName(r.Id) {
-		errList = append(errList, errors.New("'id' is not valid rune id or rune name"))
+	if r.Id != "" {
+		id, err := url.QueryUnescape(r.Id)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		r.Id = id
+		if !isRuneIdOrRuneName(r.Id) {
+			errList = append(errList, errors.Errorf("id '%s' is not valid rune id or rune name", r.Id))
+		}
 	}
 	if r.Limit < 0 {
 		errList = append(errList, errors.New("'limit' must be non-negative"))

--- a/modules/runes/api/httphandler/get_balances_by_address_batch.go
+++ b/modules/runes/api/httphandler/get_balances_by_address_batch.go
@@ -40,7 +40,7 @@ func (r getBalancesBatchRequest) Validate() error {
 			errList = append(errList, errors.Errorf("queries[%d]: 'wallet' is required", i))
 		}
 		if query.Id != "" && !isRuneIdOrRuneName(query.Id) {
-			errList = append(errList, errors.Errorf("queries[%d]: 'id' is not valid rune id or rune name", i))
+			errList = append(errList, errors.Errorf("queries[%d]: id '%s' is not valid rune id or rune name", i, query.Id))
 		}
 		if query.Limit < 0 {
 			errList = append(errList, errors.Errorf("queries[%d]: 'limit' must be non-negative", i))

--- a/modules/runes/api/httphandler/get_holders.go
+++ b/modules/runes/api/httphandler/get_holders.go
@@ -3,6 +3,7 @@ package httphandler
 import (
 	"bytes"
 	"encoding/hex"
+	"net/url"
 	"slices"
 
 	"github.com/cockroachdb/errors"
@@ -24,10 +25,15 @@ const (
 	getHoldersMaxLimit = 1000
 )
 
-func (r getHoldersRequest) Validate() error {
+func (r *getHoldersRequest) Validate() error {
 	var errList []error
+	id, err := url.QueryUnescape(r.Id)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	r.Id = id
 	if !isRuneIdOrRuneName(r.Id) {
-		errList = append(errList, errors.New("'id' is not valid rune id or rune name"))
+		errList = append(errList, errors.Errorf("id '%s' is not valid rune id or rune name", r.Id))
 	}
 	if r.Limit < 0 {
 		errList = append(errList, errors.New("'limit' must be non-negative"))

--- a/modules/runes/api/httphandler/get_token_info.go
+++ b/modules/runes/api/httphandler/get_token_info.go
@@ -1,6 +1,7 @@
 package httphandler
 
 import (
+	"net/url"
 	"slices"
 
 	"github.com/cockroachdb/errors"
@@ -17,10 +18,15 @@ type getTokenInfoRequest struct {
 	BlockHeight uint64 `query:"blockHeight"`
 }
 
-func (r getTokenInfoRequest) Validate() error {
+func (r *getTokenInfoRequest) Validate() error {
 	var errList []error
+	id, err := url.QueryUnescape(r.Id)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	r.Id = id
 	if !isRuneIdOrRuneName(r.Id) {
-		errList = append(errList, errors.New("'id' is not valid rune id or rune name"))
+		errList = append(errList, errors.Errorf("id '%s' is not valid rune id or rune name", r.Id))
 	}
 	return errs.WithPublicMessage(errors.Join(errList...), "validation error")
 }

--- a/modules/runes/api/httphandler/get_transactions.go
+++ b/modules/runes/api/httphandler/get_transactions.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"encoding/hex"
 	"fmt"
+	"net/url"
 	"slices"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -27,10 +28,17 @@ const (
 	getTransactionsMaxLimit = 3000
 )
 
-func (r getTransactionsRequest) Validate() error {
+func (r *getTransactionsRequest) Validate() error {
 	var errList []error
-	if r.Id != "" && !isRuneIdOrRuneName(r.Id) {
-		errList = append(errList, errors.New("'id' is not valid rune id or rune name"))
+	if r.Id != "" {
+		id, err := url.QueryUnescape(r.Id)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		r.Id = id
+		if !isRuneIdOrRuneName(r.Id) {
+			errList = append(errList, errors.Errorf("id '%s' is not valid rune id or rune name", r.Id))
+		}
 	}
 	if r.FromBlock < -1 {
 		errList = append(errList, errors.Errorf("invalid fromBlock range"))

--- a/modules/runes/api/httphandler/get_utxos_by_address.go
+++ b/modules/runes/api/httphandler/get_utxos_by_address.go
@@ -1,6 +1,8 @@
 package httphandler
 
 import (
+	"net/url"
+
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/cockroachdb/errors"
 	"github.com/gaze-network/indexer-network/common/errs"
@@ -22,13 +24,20 @@ const (
 	getUTXOsMaxLimit = 3000
 )
 
-func (r getUTXOsRequest) Validate() error {
+func (r *getUTXOsRequest) Validate() error {
 	var errList []error
 	if r.Wallet == "" {
 		errList = append(errList, errors.New("'wallet' is required"))
 	}
-	if r.Id != "" && !isRuneIdOrRuneName(r.Id) {
-		errList = append(errList, errors.New("'id' is not valid rune id or rune name"))
+	if r.Id != "" {
+		id, err := url.QueryUnescape(r.Id)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		r.Id = id
+		if !isRuneIdOrRuneName(r.Id) {
+			errList = append(errList, errors.Errorf("id '%s' is not valid rune id or rune name", r.Id))
+		}
 	}
 	if r.Limit < 0 {
 		errList = append(errList, errors.New("'limit' must be non-negative"))


### PR DESCRIPTION
## Description

Spacers `•` are url-encoded in req.Id, causing it to fail rune name validation if req.Id contains it. This PR unescapes the parameter before validating and using

## Type of change

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Enhancement (improvement to existing features and functionality)
- [ ] Documentation update (changes to documentation)
- [ ] Performance improvement (non-breaking change which improves efficiency)
- [ ] Code consistency (non-breaking change which improves code reliability and robustness)

## Commit formatting

Please follow the commit message conventions for an easy way to identify the purpose or intention of a commit. Check out our commit message conventions in the [CONTRIBUTING.md](https://github.com/gaze-network/gaze-indexer/blob/main/.github/CONTRIBUTING.md#pull-requests-or-commits)
