### PR TITLE
fix: wrong mint progress ordering

### DIFF
--- a/modules/runes/database/postgresql/queries/data.sql
+++ b/modules/runes/database/postgresql/queries/data.sql
@@ -86,6 +86,8 @@ SELECT * FROM runes_entries
   LEFT JOIN states ON runes_entries.rune_id = states.rune_id
   WHERE (
     runes_entries.terms = TRUE AND
+    COALESCE(runes_entries.terms_amount, 0) != 0 AND
+    COALESCE(runes_entries.terms_cap, 0) != 0 AND
     states.mints < runes_entries.terms_cap AND
     (
       runes_entries.terms_height_start IS NULL OR runes_entries.terms_height_start <= @height::integer
@@ -99,9 +101,10 @@ SELECT * FROM runes_entries
 
   ) AND (
     @search::text = '' OR
-    runes_entries.rune ILIKE @search::text || '%'
+    runes_entries.rune ILIKE '%' || @search::text || '%'
   )
-  ORDER BY (states.mints / runes_entries.terms_cap::float) DESC
+  ORDER BY (COALESCE(runes_entries.premine, 0) + COALESCE(runes_entries.terms_amount, 0) * COALESCE(states.mints, 0)) / 
+          (COALESCE(runes_entries.premine, 0) + COALESCE(runes_entries.terms_amount, 0) * COALESCE(runes_entries.terms_cap, 0))::float DESC
   LIMIT @_limit OFFSET @_offset;
 
 -- name: GetRuneIdFromRune :one

--- a/modules/runes/repository/postgres/gen/data.sql.go
+++ b/modules/runes/repository/postgres/gen/data.sql.go
@@ -437,6 +437,8 @@ SELECT runes_entries.rune_id, number, rune, spacers, premine, symbol, divisibili
   LEFT JOIN states ON runes_entries.rune_id = states.rune_id
   WHERE (
     runes_entries.terms = TRUE AND
+    COALESCE(runes_entries.terms_amount, 0) != 0 AND
+    COALESCE(runes_entries.terms_cap, 0) != 0 AND
     states.mints < runes_entries.terms_cap AND
     (
       runes_entries.terms_height_start IS NULL OR runes_entries.terms_height_start <= $1::integer
@@ -450,9 +452,10 @@ SELECT runes_entries.rune_id, number, rune, spacers, premine, symbol, divisibili
 
   ) AND (
     $2::text = '' OR
-    runes_entries.rune ILIKE $2::text || '%'
+    runes_entries.rune ILIKE '%' || $2::text || '%'
   )
-  ORDER BY (states.mints / runes_entries.terms_cap::float) DESC
+  ORDER BY (COALESCE(runes_entries.premine, 0) + COALESCE(runes_entries.terms_amount, 0) * COALESCE(states.mints, 0)) / 
+          (COALESCE(runes_entries.premine, 0) + COALESCE(runes_entries.terms_amount, 0) * COALESCE(runes_entries.terms_cap, 0))::float DESC
   LIMIT $4 OFFSET $3
 `
 


### PR DESCRIPTION
## Description
- Take premine into account when ordering for Get Ongoing Runes
- Change search logic to be `contains` instead of `prefix`

## Type of change

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Enhancement (improvement to existing features and functionality)
- [ ] Documentation update (changes to documentation)
- [ ] Performance improvement (non-breaking change which improves efficiency)
- [ ] Code consistency (non-breaking change which improves code reliability and robustness)

## Commit formatting

Please follow the commit message conventions for an easy way to identify the purpose or intention of a commit. Check out our commit message conventions in the [CONTRIBUTING.md](https://github.com/gaze-network/gaze-indexer/blob/main/.github/CONTRIBUTING.md#pull-requests-or-commits)
