### PR TITLE
feat: add get Runes info batch api

### DIFF
--- a/modules/runes/api/httphandler/get_holders.go
+++ b/modules/runes/api/httphandler/get_holders.go
@@ -3,6 +3,7 @@ package httphandler
 import (
 	"bytes"
 	"encoding/hex"
+	"fmt"
 	"net/url"
 	"slices"
 
@@ -90,7 +91,7 @@ func (h *HttpHandler) GetHolders(ctx *fiber.Ctx) (err error) {
 		var ok bool
 		runeId, ok = h.resolveRuneId(ctx.UserContext(), req.Id)
 		if !ok {
-			return errs.NewPublicError("unable to resolve rune id from \"id\"")
+			return errs.NewPublicError(fmt.Sprintf("unable to resolve rune id \"%s\" from \"id\"", req.Id))
 		}
 	}
 

--- a/modules/runes/api/httphandler/get_token_info.go
+++ b/modules/runes/api/httphandler/get_token_info.go
@@ -31,6 +31,10 @@ func (r *getTokenInfoRequest) Validate() error {
 		errList = append(errList, errors.Errorf("id '%s' is not valid rune id or rune name", r.Id))
 	}
 
+	if r.AdditionalFieldsRaw == "" {
+		// temporarily set default value for backward compatibility
+		r.AdditionalFieldsRaw = "holdersCount" // TODO: remove this default value after all clients are updated
+	}
 	r.AdditionalFields = strings.Split(r.AdditionalFieldsRaw, ",")
 
 	return errs.WithPublicMessage(errors.Join(errList...), "validation error")

--- a/modules/runes/api/httphandler/get_token_info.go
+++ b/modules/runes/api/httphandler/get_token_info.go
@@ -3,6 +3,7 @@ package httphandler
 import (
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/cockroachdb/errors"
 	"github.com/gaze-network/indexer-network/common/errs"
@@ -13,9 +14,10 @@ import (
 )
 
 type getTokenInfoRequest struct {
-	Id               string   `params:"id"`
-	BlockHeight      uint64   `query:"blockHeight"`
-	AdditionalFields []string `query:"additionalFields"` // comma-separated list of additional fields
+	Id                  string `params:"id"`
+	BlockHeight         uint64 `query:"blockHeight"`
+	AdditionalFieldsRaw string `query:"additionalFields"` // comma-separated list of additional fields
+	AdditionalFields    []string
 }
 
 func (r *getTokenInfoRequest) Validate() error {
@@ -28,6 +30,8 @@ func (r *getTokenInfoRequest) Validate() error {
 	if !isRuneIdOrRuneName(r.Id) {
 		errList = append(errList, errors.Errorf("id '%s' is not valid rune id or rune name", r.Id))
 	}
+
+	r.AdditionalFields = strings.Split(r.AdditionalFieldsRaw, ",")
 
 	return errs.WithPublicMessage(errors.Join(errList...), "validation error")
 }

--- a/modules/runes/api/httphandler/get_token_info.go
+++ b/modules/runes/api/httphandler/get_token_info.go
@@ -101,7 +101,7 @@ func (h *HttpHandler) GetTokenInfo(ctx *fiber.Ctx) (err error) {
 		var ok bool
 		runeId, ok = h.resolveRuneId(ctx.UserContext(), req.Id)
 		if !ok {
-			return errs.NewPublicError("unable to resolve rune id from \"id\"")
+			return errs.NewPublicError(fmt.Sprintf("unable to resolve rune id \"%s\" from \"id\"", req.Id))
 		}
 	}
 

--- a/modules/runes/api/httphandler/get_token_info_batch.go
+++ b/modules/runes/api/httphandler/get_token_info_batch.go
@@ -111,51 +111,9 @@ func (h *HttpHandler) GetTokenInfoBatch(ctx *fiber.Ctx) (err error) {
 		}
 		holdersCount := holdersCounts[runeId]
 
-		totalSupply, err := runeEntry.Supply()
+		result, err := createTokenInfoResult(runeEntry, holdersCount)
 		if err != nil {
-			return errors.Wrap(err, "cannot get total supply of rune")
-		}
-		mintedAmount, err := runeEntry.MintedAmount()
-		if err != nil {
-			return errors.Wrap(err, "cannot get minted amount of rune")
-		}
-		circulatingSupply := mintedAmount.Sub(runeEntry.BurnedAmount)
-
-		terms := lo.FromPtr(runeEntry.Terms)
-
-		result := &getTokenInfoResult{
-			Id:                runeId,
-			Name:              runeEntry.SpacedRune,
-			Symbol:            string(runeEntry.Symbol),
-			TotalSupply:       totalSupply,
-			CirculatingSupply: circulatingSupply,
-			MintedAmount:      mintedAmount,
-			BurnedAmount:      runeEntry.BurnedAmount,
-			Decimals:          runeEntry.Divisibility,
-			DeployedAt:        runeEntry.EtchedAt.Unix(),
-			DeployedAtHeight:  runeEntry.EtchingBlock,
-			CompletedAt:       lo.Ternary(runeEntry.CompletedAt.IsZero(), nil, lo.ToPtr(runeEntry.CompletedAt.Unix())),
-			CompletedAtHeight: runeEntry.CompletedAtHeight,
-			HoldersCount:      holdersCount,
-			Extend: tokenInfoExtend{
-				Entry: entry{
-					Divisibility: runeEntry.Divisibility,
-					Premine:      runeEntry.Premine,
-					Rune:         runeEntry.SpacedRune.Rune,
-					Spacers:      runeEntry.SpacedRune.Spacers,
-					Symbol:       string(runeEntry.Symbol),
-					Terms: entryTerms{
-						Amount:      lo.FromPtr(terms.Amount),
-						Cap:         lo.FromPtr(terms.Cap),
-						HeightStart: terms.HeightStart,
-						HeightEnd:   terms.HeightEnd,
-						OffsetStart: terms.OffsetStart,
-						OffsetEnd:   terms.OffsetEnd,
-					},
-					Turbo:         runeEntry.Turbo,
-					EtchingTxHash: runeEntry.EtchingTxHash.String(),
-				},
-			},
+			return errors.Wrap(err, "error during createTokenInfoResult")
 		}
 		results = append(results, result)
 	}

--- a/modules/runes/api/httphandler/get_token_info_batch.go
+++ b/modules/runes/api/httphandler/get_token_info_batch.go
@@ -85,9 +85,6 @@ func (h *HttpHandler) GetTokenInfoBatch(ctx *fiber.Ctx) (err error) {
 	if lo.Contains(req.AdditionalFields, "holdersCount") {
 		holdersCounts, err = h.usecase.GetTotalHoldersByRuneIds(ctx.UserContext(), runeIds, blockHeight)
 		if err != nil {
-			if errors.Is(err, errs.NotFound) {
-				return errs.NewPublicError("rune not found")
-			}
 			return errors.Wrap(err, "error during GetBalancesByRuneId")
 		}
 	}

--- a/modules/runes/api/httphandler/get_token_info_batch.go
+++ b/modules/runes/api/httphandler/get_token_info_batch.go
@@ -14,7 +14,7 @@ import (
 type getTokenInfoBatchRequest struct {
 	Ids              []string `json:"ids"`
 	BlockHeight      uint64   `json:"blockHeight"`
-	AdditionalFields []string `query:"additionalFields"`
+	AdditionalFields []string `json:"additionalFields"`
 }
 
 const getTokenInfoBatchMaxQueries = 100

--- a/modules/runes/api/httphandler/get_token_info_batch.go
+++ b/modules/runes/api/httphandler/get_token_info_batch.go
@@ -23,7 +23,7 @@ func (r *getTokenInfoBatchRequest) Validate() error {
 	var errList []error
 
 	if len(r.Ids) == 0 {
-		errList = append(errList, errors.New("at least one query is required"))
+		errList = append(errList, errors.New("ids cannot be empty"))
 	}
 	if len(r.Ids) > getTokenInfoBatchMaxQueries {
 		errList = append(errList, errors.Errorf("cannot query more than %d ids", getTokenInfoBatchMaxQueries))

--- a/modules/runes/api/httphandler/get_token_info_batch.go
+++ b/modules/runes/api/httphandler/get_token_info_batch.go
@@ -1,0 +1,170 @@
+package httphandler
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/cockroachdb/errors"
+	"github.com/gaze-network/indexer-network/common/errs"
+	"github.com/gaze-network/indexer-network/modules/runes/runes"
+	"github.com/gofiber/fiber/v2"
+	"github.com/samber/lo"
+)
+
+type getTokenInfoBatchRequest struct {
+	Ids                 []string `json:"ids"`
+	BlockHeight         uint64   `json:"blockHeight"`
+	IncludeHoldersCount *bool    `json:"includeHoldersCount"`
+}
+
+func (r *getTokenInfoBatchRequest) ParseDefault() error {
+	if r.IncludeHoldersCount == nil {
+		r.IncludeHoldersCount = lo.ToPtr(false)
+	}
+	return nil
+}
+
+const getTokenInfoBatchMaxQueries = 100
+
+func (r *getTokenInfoBatchRequest) Validate() error {
+	var errList []error
+
+	if len(r.Ids) == 0 {
+		errList = append(errList, errors.New("at least one query is required"))
+	}
+	if len(r.Ids) > getTokenInfoBatchMaxQueries {
+		errList = append(errList, errors.Errorf("cannot query more than %d ids", getTokenInfoBatchMaxQueries))
+	}
+	for i := range r.Ids {
+		id, err := url.QueryUnescape(r.Ids[i])
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		r.Ids[i] = id
+		if !isRuneIdOrRuneName(r.Ids[i]) {
+			errList = append(errList, errors.Errorf("ids[%d]: id '%s' is not valid rune id or rune name", i, r.Ids[i]))
+		}
+	}
+
+	return errs.WithPublicMessage(errors.Join(errList...), "validation error")
+}
+
+type getTokenInfoBatchResult struct {
+	List []*getTokenInfoResult `json:"list"`
+}
+type getTokenInfoBatchResponse = HttpResponse[getTokenInfoBatchResult]
+
+func (h *HttpHandler) GetTokenInfoBatch(ctx *fiber.Ctx) (err error) {
+	var req getTokenInfoBatchRequest
+	if err := ctx.BodyParser(&req); err != nil {
+		return errors.WithStack(err)
+	}
+	if err := req.Validate(); err != nil {
+		return errors.WithStack(err)
+	}
+	if err := req.ParseDefault(); err != nil {
+		return errors.WithStack(err)
+	}
+
+	blockHeight := req.BlockHeight
+	if blockHeight == 0 {
+		blockHeader, err := h.usecase.GetLatestBlock(ctx.UserContext())
+		if err != nil {
+			if errors.Is(err, errs.NotFound) {
+				return errs.NewPublicError("latest block not found")
+			}
+			return errors.Wrap(err, "error during GetLatestBlock")
+		}
+		blockHeight = uint64(blockHeader.Height)
+	}
+
+	runeIds := make([]runes.RuneId, 0)
+	for i, id := range req.Ids {
+		runeId, ok := h.resolveRuneId(ctx.UserContext(), id)
+		if !ok {
+			return errs.NewPublicError(fmt.Sprintf("unable to resolve rune id \"%s\" from \"ids[%d]\"", id, i))
+		}
+		runeIds = append(runeIds, runeId)
+	}
+
+	runeEntries, err := h.usecase.GetRuneEntryByRuneIdAndHeightBatch(ctx.UserContext(), runeIds, blockHeight)
+	if err != nil {
+		return errors.Wrap(err, "error during GetRuneEntryByRuneIdAndHeightBatch")
+	}
+	holdersCounts := make(map[runes.RuneId]int64)
+	if *req.IncludeHoldersCount {
+		holdersCounts, err = h.usecase.GetTotalHoldersByRuneIds(ctx.UserContext(), runeIds, blockHeight)
+		if err != nil {
+			if errors.Is(err, errs.NotFound) {
+				return errs.NewPublicError("rune not found")
+			}
+			return errors.Wrap(err, "error during GetBalancesByRuneId")
+		}
+	}
+
+	results := make([]*getTokenInfoResult, 0, len(runeIds))
+
+	for _, runeId := range runeIds {
+		runeEntry, ok := runeEntries[runeId]
+		if !ok {
+			return errs.NewPublicError(fmt.Sprintf("rune not found: %s", runeId))
+		}
+		holdersCount := holdersCounts[runeId]
+
+		totalSupply, err := runeEntry.Supply()
+		if err != nil {
+			return errors.Wrap(err, "cannot get total supply of rune")
+		}
+		mintedAmount, err := runeEntry.MintedAmount()
+		if err != nil {
+			return errors.Wrap(err, "cannot get minted amount of rune")
+		}
+		circulatingSupply := mintedAmount.Sub(runeEntry.BurnedAmount)
+
+		terms := lo.FromPtr(runeEntry.Terms)
+
+		result := &getTokenInfoResult{
+			Id:                runeId,
+			Name:              runeEntry.SpacedRune,
+			Symbol:            string(runeEntry.Symbol),
+			TotalSupply:       totalSupply,
+			CirculatingSupply: circulatingSupply,
+			MintedAmount:      mintedAmount,
+			BurnedAmount:      runeEntry.BurnedAmount,
+			Decimals:          runeEntry.Divisibility,
+			DeployedAt:        runeEntry.EtchedAt.Unix(),
+			DeployedAtHeight:  runeEntry.EtchingBlock,
+			CompletedAt:       lo.Ternary(runeEntry.CompletedAt.IsZero(), nil, lo.ToPtr(runeEntry.CompletedAt.Unix())),
+			CompletedAtHeight: runeEntry.CompletedAtHeight,
+			HoldersCount:      holdersCount,
+			Extend: tokenInfoExtend{
+				Entry: entry{
+					Divisibility: runeEntry.Divisibility,
+					Premine:      runeEntry.Premine,
+					Rune:         runeEntry.SpacedRune.Rune,
+					Spacers:      runeEntry.SpacedRune.Spacers,
+					Symbol:       string(runeEntry.Symbol),
+					Terms: entryTerms{
+						Amount:      lo.FromPtr(terms.Amount),
+						Cap:         lo.FromPtr(terms.Cap),
+						HeightStart: terms.HeightStart,
+						HeightEnd:   terms.HeightEnd,
+						OffsetStart: terms.OffsetStart,
+						OffsetEnd:   terms.OffsetEnd,
+					},
+					Turbo:         runeEntry.Turbo,
+					EtchingTxHash: runeEntry.EtchingTxHash.String(),
+				},
+			},
+		}
+		results = append(results, result)
+	}
+
+	resp := getTokenInfoBatchResponse{
+		Result: &getTokenInfoBatchResult{
+			List: results,
+		},
+	}
+
+	return errors.WithStack(ctx.JSON(resp))
+}

--- a/modules/runes/api/httphandler/get_tokens.go
+++ b/modules/runes/api/httphandler/get_tokens.go
@@ -142,7 +142,7 @@ func (h *HttpHandler) GetTokens(ctx *fiber.Ctx) (err error) {
 			DeployedAtHeight:  ent.EtchingBlock,
 			CompletedAt:       lo.Ternary(ent.CompletedAt.IsZero(), nil, lo.ToPtr(ent.CompletedAt.Unix())),
 			CompletedAtHeight: ent.CompletedAtHeight,
-			HoldersCount:      int(totalHolders[ent.RuneId]),
+			HoldersCount:      totalHolders[ent.RuneId],
 			Extend: tokenInfoExtend{
 				Entry: entry{
 					Divisibility: ent.Divisibility,

--- a/modules/runes/api/httphandler/get_tokens.go
+++ b/modules/runes/api/httphandler/get_tokens.go
@@ -32,23 +32,27 @@ func (s GetTokensScope) IsValid() bool {
 
 type getTokensRequest struct {
 	paginationRequest
-	Search           string         `query:"search"`
-	BlockHeight      uint64         `query:"blockHeight"`
-	Scope            GetTokensScope `query:"scope"`
-	AdditionalFields []string       `query:"additionalFields"` // comma-separated list of additional fields
+	Search              string         `query:"search"`
+	BlockHeight         uint64         `query:"blockHeight"`
+	Scope               GetTokensScope `query:"scope"`
+	AdditionalFieldsRaw string         `query:"additionalFields"` // comma-separated list of additional fields
+	AdditionalFields    []string
 }
 
-func (req getTokensRequest) Validate() error {
+func (r *getTokensRequest) Validate() error {
 	var errList []error
-	if err := req.paginationRequest.Validate(); err != nil {
+	if err := r.paginationRequest.Validate(); err != nil {
 		errList = append(errList, err)
 	}
-	if req.Limit > getTokensMaxLimit {
+	if r.Limit > getTokensMaxLimit {
 		errList = append(errList, errors.Errorf("limit must be less than or equal to 1000"))
 	}
-	if req.Scope != "" && !req.Scope.IsValid() {
-		errList = append(errList, errors.Errorf("invalid scope: %s", req.Scope))
+	if r.Scope != "" && !r.Scope.IsValid() {
+		errList = append(errList, errors.Errorf("invalid scope: %s", r.Scope))
 	}
+
+	r.AdditionalFields = strings.Split(r.AdditionalFieldsRaw, ",")
+
 	return errs.WithPublicMessage(errors.Join(errList...), "validation error")
 }
 

--- a/modules/runes/api/httphandler/get_tokens.go
+++ b/modules/runes/api/httphandler/get_tokens.go
@@ -51,6 +51,10 @@ func (r *getTokensRequest) Validate() error {
 		errList = append(errList, errors.Errorf("invalid scope: %s", r.Scope))
 	}
 
+	if r.AdditionalFieldsRaw == "" {
+		// temporarily set default value for backward compatibility
+		r.AdditionalFieldsRaw = "holdersCount" // TODO: remove this default value after all clients are updated
+	}
 	r.AdditionalFields = strings.Split(r.AdditionalFieldsRaw, ",")
 
 	return errs.WithPublicMessage(errors.Join(errList...), "validation error")

--- a/modules/runes/api/httphandler/get_transactions.go
+++ b/modules/runes/api/httphandler/get_transactions.go
@@ -152,7 +152,7 @@ func (h *HttpHandler) GetTransactions(ctx *fiber.Ctx) (err error) {
 		var ok bool
 		runeId, ok = h.resolveRuneId(ctx.UserContext(), req.Id)
 		if !ok {
-			return errs.NewPublicError("unable to resolve rune id from \"id\"")
+			return errs.NewPublicError(fmt.Sprintf("unable to resolve rune id \"%s\" from \"id\"", req.Id))
 		}
 	}
 

--- a/modules/runes/api/httphandler/routes.go
+++ b/modules/runes/api/httphandler/routes.go
@@ -12,6 +12,7 @@ func (h *HttpHandler) Mount(router fiber.Router) error {
 	r.Get("/transactions", h.GetTransactions)
 	r.Get("/transactions/hash/:hash", h.GetTransactionByHash)
 	r.Get("/holders/:id", h.GetHolders)
+	r.Post("/info/batch", h.GetTokenInfoBatch)
 	r.Get("/info/:id", h.GetTokenInfo)
 	r.Get("/utxos/wallet/:wallet", h.GetUTXOs)
 	r.Post("/utxos/output/batch", h.GetUTXOsOutputByLocationBatch)

--- a/modules/runes/usecase/get_balances.go
+++ b/modules/runes/usecase/get_balances.go
@@ -33,3 +33,13 @@ func (u *Usecase) GetTotalHoldersByRuneIds(ctx context.Context, runeIds []runes.
 	}
 	return holders, nil
 }
+
+func (u *Usecase) GetTotalHoldersByRuneId(ctx context.Context, runeId runes.RuneId, blockHeight uint64) (int64, error) {
+	holders, err := u.runesDg.GetTotalHoldersByRuneIds(ctx, []runes.RuneId{runeId}, blockHeight)
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to get total holders by rune ids")
+	}
+
+	// defaults to zero holders if not found
+	return holders[runeId], nil
+}

--- a/modules/runes/usecase/get_rune_entry.go
+++ b/modules/runes/usecase/get_rune_entry.go
@@ -40,11 +40,11 @@ func (u *Usecase) GetRuneEntryByRuneIdAndHeight(ctx context.Context, runeId rune
 }
 
 func (u *Usecase) GetRuneEntryByRuneIdAndHeightBatch(ctx context.Context, runeIds []runes.RuneId, blockHeight uint64) (map[runes.RuneId]*runes.RuneEntry, error) {
-	runeEntry, err := u.runesDg.GetRuneEntryByRuneIdAndHeightBatch(ctx, runeIds, blockHeight)
+	runeEntries, err := u.runesDg.GetRuneEntryByRuneIdAndHeightBatch(ctx, runeIds, blockHeight)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get rune entries by rune ids and height")
 	}
-	return runeEntry, nil
+	return runeEntries, nil
 }
 
 func (u *Usecase) GetRuneEntries(ctx context.Context, search string, blockHeight uint64, limit, offset int32) ([]*runes.RuneEntry, error) {


### PR DESCRIPTION
## Description
- Adds "GET /info/batch" for batch querying Runes info
- Adds "includeHoldersCount" flag in `Get Token Info` / `Get Token Info Batch` / `Get Tokens`.
  - If false, set "holdersCount" field to 0.
  - If true, query holders count as normal
- BREAKING: includeHoldersCount will default to `false`, instead of `true` (current behavior)

## Type of change

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Enhancement (improvement to existing features and functionality)
- [ ] Documentation update (changes to documentation)
- [ ] Performance improvement (non-breaking change which improves efficiency)
- [ ] Code consistency (non-breaking change which improves code reliability and robustness)

## Commit formatting

Please follow the commit message conventions for an easy way to identify the purpose or intention of a commit. Check out our commit message conventions in the [CONTRIBUTING.md](https://github.com/gaze-network/gaze-indexer/blob/main/.github/CONTRIBUTING.md#pull-requests-or-commits)
